### PR TITLE
fix(login): 認証情報からproviderTokenが欠けていた場合にログインモーダルが出ないが、/share配下にアクセスでき…

### DIFF
--- a/app/repository-view/page.tsx
+++ b/app/repository-view/page.tsx
@@ -13,32 +13,6 @@ export default function Page() {
   return (
     <div className="flex">
       <div className="w-1/4 bg-white h-screen">
-        {/* <div className="w-11/12 bg-gray-100 mx-auto p-1 rounded-sm">
-          <div className="flex">
-            <div
-              className={`w-1/2 text-center py-2 ${
-                isPersonalClicked && "bg-white"
-              }`}
-              onClick={clickPersonal}
-            >
-              <div className="flex items-center justify-center rounded">
-                <FaUser className="mr-2" />
-                <span className="text-sm text-gray-500">個人</span>
-              </div>
-            </div>
-            <div
-              className={`w-1/2 text-center rounded py-2 ${
-                !isPersonalClicked && "bg-white"
-              }`}
-              onClick={clickOrganizations}
-            >
-              <div className="flex items-center justify-center">
-                <FaUsers className="mr-2" />
-                <span className="text-sm text-gray-500">組織</span>
-              </div>
-            </div>
-          </div>
-        </div> */}
         <RepositoryTypeSelctor
           isPersonalClicked={isPersonalClicked}
           clickPersonal={clickPersonal}

--- a/datas/fetchAuthUserRespositories.ts
+++ b/datas/fetchAuthUserRespositories.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { RepositoryList } from "@/types/fetchRepositoryType";
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+import { cookies } from "next/headers";
 
 export async function fetchAuthenticatedUserRepositoryNames() {
   const supabase = createClient();
@@ -11,7 +12,19 @@ export async function fetchAuthenticatedUserRepositoryNames() {
   const { data } = await supabase.auth.getSession();
   const providerToken = data.session?.provider_token!;
 
+  /* TODO:場当たり的な対処をしている
+  https://github.com/warabimochi1126/EnvHub/issues/123
+   */
   if (!providerToken) {
+    console.log("providerTokenなくてひっかかってる");
+
+    // 場当たり的な解決策
+    const cookieStore = cookies();
+    const allCookies = cookieStore.getAll();
+    allCookies.forEach((cookie) => {
+      cookieStore.delete(cookie.name);
+    });
+
     redirect("/");
   }
 


### PR DESCRIPTION
…ない問題の修正

# 概要
標題の通りです。
# 補足情報

- 場当たり的な対処になっているので、後で対応策を考える必要がある
- supabaseからの脱却を視野に入れても良い(サーバサイドでアクセスするには少し辛い、FEからのdocs以外は充実していない)

# 関連 Issue

close https://github.com/warabimochi1126/EnvHub/issues/123
