### PR TITLE
feat(postpage): organizations名を描画するアコーディオンメニューの実装

### DIFF
--- a/app/repository-view/page.tsx
+++ b/app/repository-view/page.tsx
@@ -5,8 +5,28 @@ import { FaUser } from "react-icons/fa";
 import { FaUsers } from "react-icons/fa";
 import { TbZoom } from "react-icons/tb";
 import { FcFolder } from "react-icons/fc";
+import { IoLogoGithub } from "react-icons/io";
+
+import { MdKeyboardDoubleArrowRight } from "react-icons/md";
+import { MdKeyboardDoubleArrowDown } from "react-icons/md";
+
+import {
+  Accordion,
+  AccordionItem,
+  AccordionItemHeading,
+  AccordionItemButton,
+  AccordionItemPanel,
+} from "react-accessible-accordion";
 
 const repoNamesData = ["EnvHub", "GitHub-actions-learn", "e-ten"];
+const orgsData = [
+  { orgName: "team-kaihatu1", repoName: ["team-repo-a-1"] },
+  { orgName: "team-kaihatu2", repoName: ["team-repo-a-2", "team-repo-b-2"] },
+  {
+    orgName: "team-kaihatu3",
+    repoName: ["team-repo-a-3", "team-repo-b-3", "team-repo-c-3"],
+  },
+];
 // TODO:コンポーネント分割・カスタムフックスの作成
 export default function Page() {
   const [isPersonalClicked, setIsPersonalClicked] = useState<boolean>(true);
@@ -23,15 +43,9 @@ export default function Page() {
         />
         <RepoNameSearchBar />
         {repoNamesData.map((repoName, index) => (
-          // <div
-          //   key={index}
-          //   className="w-11/12 mx-auto border rounded p-2 flex items-center text-sm"
-          // >
-          //   <FcFolder className="mr-2" size={20} />
-          //   <span>{repoName}</span>
-          // </div>
           <RepoSelectButton key={index} repoName={repoName} />
         ))}
+        <OrganizationsAccordionWrapper />
       </div>
       <div className="w-3/4 bg-[#F3F4F6]">
         <span>aaa</span>
@@ -148,5 +162,65 @@ export function RepoSelectButton({ repoName }: RepoSelectButtonProps) {
       <FcFolder className="mr-2" size={20} />
       <span>{repoName}</span>
     </div>
+  );
+}
+
+interface OrganizationsSelectButtonProps {
+  organizationName: string;
+  isAccordionClicked: boolean;
+}
+
+export function OrganizationsSelectButton({
+  organizationName,
+  isAccordionClicked,
+}: OrganizationsSelectButtonProps) {
+  return (
+    <div className="w-11/12 mx-auto border rounded flex items-center p-2 justify-between">
+      <IoLogoGithub className="mr-2" size={20} />
+      <span>{organizationName}</span>
+      {isAccordionClicked ? (
+        <MdKeyboardDoubleArrowDown size={25} />
+      ) : (
+        <MdKeyboardDoubleArrowRight size={25} />
+      )}
+    </div>
+  );
+}
+
+export function OrganizationsAccordionWrapper() {
+  const [toggleOrgName, setToggleOrgName] = useState<string>("");
+
+  const toggleOrgNameHandler = (currentClickOrgName: string) => {
+    if (toggleOrgName === currentClickOrgName) {
+      setToggleOrgName("");
+      return;
+    }
+
+    setToggleOrgName(currentClickOrgName);
+  };
+
+  return (
+    <Accordion allowZeroExpanded>
+      {orgsData.map((orgData, index) => (
+        <AccordionItem key={index}>
+          <AccordionItemHeading
+            onClick={() => toggleOrgNameHandler(orgData.orgName)}
+          >
+            <AccordionItemButton>
+              <OrganizationsSelectButton
+                organizationName={orgData.orgName}
+                isAccordionClicked={orgData.orgName === toggleOrgName}
+              />
+            </AccordionItemButton>
+          </AccordionItemHeading>
+          <AccordionItemPanel>
+            {orgData.repoName.map((repoName, index) => (
+              <RepoSelectButton key={index} repoName={repoName} />
+            ))}
+          </AccordionItemPanel>
+        </AccordionItem>
+      ))}
+      {/* </AccordionItem> */}
+    </Accordion>
   );
 }


### PR DESCRIPTION
# 概要
標題の通りです。

# 動作確認手順
app/repository-viewで確認出来ます。
# 関連 Issue

close https://github.com/warabimochi1126/EnvHub/issues/121