### PR TITLE
feat(postpage): アップロード確定ボタン押下後にモーダルを遷移させる

### DIFF
--- a/app/components/post/elements/inmodal/during/upload-during-modal-content.tsx
+++ b/app/components/post/elements/inmodal/during/upload-during-modal-content.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { PulseLoader } from "react-spinners";
+
+export function UploadDuringModalContent() {
+  return (
+    <>
+      <div className="flex flex-col justify-center items-center h-52">
+        <PulseLoader speedMultiplier={0.2} color="#3B82F6" size={20} />
+        <p className="text-gray-600 mt-3">アップロード中です...</p>
+      </div>
+    </>
+  );
+}

--- a/app/components/post/elements/inmodal/result/fail/upload-fail-modal-button.tsx
+++ b/app/components/post/elements/inmodal/result/fail/upload-fail-modal-button.tsx
@@ -1,8 +1,17 @@
+"use client";
+
 import { FiRefreshCw } from "react-icons/fi";
 
 export function UploadFailModalButton() {
+  const reloadCurrentPage = () => {
+    window.location.reload();
+  };
+
   return (
-    <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-red-500 hover:bg-red-400 transition-colors duration-300">
+    <button
+      className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-red-500 hover:bg-red-400 transition-colors duration-300"
+      onClick={() => reloadCurrentPage()}
+    >
       <FiRefreshCw className="mr-2" />
       再アップロードを行う
     </button>

--- a/app/components/post/elements/inmodal/result/fail/upload-fail-modal-button.tsx
+++ b/app/components/post/elements/inmodal/result/fail/upload-fail-modal-button.tsx
@@ -1,0 +1,10 @@
+import { FiRefreshCw } from "react-icons/fi";
+
+export function UploadFailModalButton() {
+  return (
+    <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-red-500 hover:bg-red-400 transition-colors duration-300">
+      <FiRefreshCw className="mr-2" />
+      再アップロードを行う
+    </button>
+  );
+}

--- a/app/components/post/elements/inmodal/result/fail/upload-fail-modal-content.tsx
+++ b/app/components/post/elements/inmodal/result/fail/upload-fail-modal-content.tsx
@@ -1,0 +1,10 @@
+import { MdError } from "react-icons/md";
+
+export function UploadFailModalContent() {
+  return (
+    <>
+      <MdError size={100} className="text-red-500" />
+      <p className="text-red-400">アップロードに失敗しました。</p>
+    </>
+  );
+}

--- a/app/components/post/elements/inmodal/result/success/upload-success-modal-button.tsx
+++ b/app/components/post/elements/inmodal/result/success/upload-success-modal-button.tsx
@@ -1,0 +1,10 @@
+import { FaArrowRight } from "react-icons/fa";
+
+export function UploadSuccessModalButton() {
+  return (
+    <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-green-600 hover:bg-green-500 transition-colors duration-300">
+      アップロードを確認する
+      <FaArrowRight className="ml-2" />
+    </button>
+  );
+}

--- a/app/components/post/elements/inmodal/result/success/upload-success-modal-content.tsx
+++ b/app/components/post/elements/inmodal/result/success/upload-success-modal-content.tsx
@@ -1,0 +1,10 @@
+import { BsCheck2Circle } from "react-icons/bs";
+
+export function UploadSuccessModalContent() {
+  return (
+    <>
+      <BsCheck2Circle size={100} color="10B981" />
+      <p className="text-gray-600">アップロードが完了しました！</p>
+    </>
+  );
+}

--- a/app/components/post/elements/inmodal/result/upload-result-modal-content.tsx
+++ b/app/components/post/elements/inmodal/result/upload-result-modal-content.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { BsCheck2Circle } from "react-icons/bs";
-import { FaArrowRight } from "react-icons/fa";
-import { BsExclamationTriangle } from "react-icons/bs";
-import { MdError } from "react-icons/md";
-import { FiRefreshCw } from "react-icons/fi";
+import { UploadFailModalButton } from "./fail/upload-fail-modal-button";
+import { UploadFailModalContent } from "./fail/upload-fail-modal-content";
+import { UploadSuccessModalButton } from "./success/upload-success-modal-button";
+import { UploadSuccessModalContent } from "./success/upload-success-modal-content";
 
 interface UploadResultModalContentProps {
   result: "SUCCESS" | "FAIL";
@@ -15,20 +14,10 @@ export function UploadResultModalContent({ result }: UploadResultModalContentPro
     <div>
       <h1 className="font-bold text-lg">アップロード結果</h1>
       <div className="flex flex-col justify-center items-center">
-        {/* <BsCheck2Circle size={100} color="10B981" /> */}
-        {/* <p className="text-gray-600">アップロードが完了しました！</p> */}
-        <MdError size={100} className="text-red-500" />
-        <p className="text-red-400">アップロードに失敗しました。</p>
+        {result === "SUCCESS" ? <UploadSuccessModalContent /> : <UploadFailModalContent />}
       </div>
       <hr className="mt-2 h-2" />
-      {/* <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-green-600 hover:bg-green-500 transition-colors duration-300">
-        アップロードを確認する
-        <FaArrowRight className="ml-2" />
-      </button> */}
-      <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-red-500 hover:bg-red-400 transition-colors duration-300">
-        <FiRefreshCw className="mr-2" />
-        再アップロードを行う
-      </button>
+      {result === "SUCCESS" ? <UploadSuccessModalButton /> : <UploadFailModalButton />}
     </div>
   );
 }

--- a/app/components/post/elements/inmodal/result/upload-result-modal-content.tsx
+++ b/app/components/post/elements/inmodal/result/upload-result-modal-content.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { BsCheck2Circle } from "react-icons/bs";
+import { FaArrowRight } from "react-icons/fa";
+import { BsExclamationTriangle } from "react-icons/bs";
+import { MdError } from "react-icons/md";
+import { FiRefreshCw } from "react-icons/fi";
+
+interface UploadResultModalContentProps {
+  result: "SUCCESS" | "FAIL";
+}
+
+export function UploadResultModalContent({ result }: UploadResultModalContentProps) {
+  return (
+    <div>
+      <h1 className="font-bold text-lg">アップロード結果</h1>
+      <div className="flex flex-col justify-center items-center">
+        {/* <BsCheck2Circle size={100} color="10B981" /> */}
+        {/* <p className="text-gray-600">アップロードが完了しました！</p> */}
+        <MdError size={100} className="text-red-500" />
+        <p className="text-red-400">アップロードに失敗しました。</p>
+      </div>
+      <hr className="mt-2 h-2" />
+      {/* <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-green-600 hover:bg-green-500 transition-colors duration-300">
+        アップロードを確認する
+        <FaArrowRight className="ml-2" />
+      </button> */}
+      <button className="w-full border rounded-lg py-2 flex items-center justify-center text-white bg-red-500 hover:bg-red-400 transition-colors duration-300">
+        <FiRefreshCw className="mr-2" />
+        再アップロードを行う
+      </button>
+    </div>
+  );
+}

--- a/app/components/post/elements/inmodal/upload-modal-footer-button.tsx
+++ b/app/components/post/elements/inmodal/upload-modal-footer-button.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import { useRepoDataStore } from "@/store/repositoryGlobalState";
+import { Dispatch, SetStateAction } from "react";
+import { CommitState } from "../upload-confirm-button";
 
 interface UploadModalFooterButtonProps {
   modalClose: () => void;
   uploadFiles: File[];
   commitMessage: string;
+  setCommitState: Dispatch<SetStateAction<CommitState>>;
 }
 // prettier-ignore
-export function UploadModalFooter({ modalClose, uploadFiles, commitMessage }: UploadModalFooterButtonProps) {
+export function UploadModalFooterButton({ modalClose, uploadFiles, commitMessage, setCommitState }: UploadModalFooterButtonProps) {
   const { selectedRepoData } = useRepoDataStore();
 
   const confirmUpload = (uploadTargetFiles: File[]) => {
@@ -21,8 +24,10 @@ export function UploadModalFooter({ modalClose, uploadFiles, commitMessage }: Up
       repo_name: selectedRepoData.repoName,
       repo_id: selectedRepoData.repoId,
       commit_message: commitMessage
-    }))
+    }));
 
+    setCommitState("DURING");
+    
     const response = fetch("/api/uploads/confirm", {
       method: "POST",
       body: uploadRequestBody,

--- a/app/components/post/elements/inmodal/upload-modal-footer-button.tsx
+++ b/app/components/post/elements/inmodal/upload-modal-footer-button.tsx
@@ -14,9 +14,10 @@ interface UploadModalFooterButtonProps {
 export function UploadModalFooterButton({ modalClose, uploadFiles, commitMessage, setCommitState }: UploadModalFooterButtonProps) {
   const { selectedRepoData } = useRepoDataStore();
 
-  const confirmUpload = (uploadTargetFiles: File[]) => {
-    const uploadRequestBody = new FormData();
+  const confirmUpload = async (uploadTargetFiles: File[]) => {
+    setCommitState("DURING");
 
+    const uploadRequestBody = new FormData();
     uploadTargetFiles.forEach((uploadTargetFile) => {
       uploadRequestBody.append("upload_target_files", uploadTargetFile);
     });
@@ -25,13 +26,17 @@ export function UploadModalFooterButton({ modalClose, uploadFiles, commitMessage
       repo_id: selectedRepoData.repoId,
       commit_message: commitMessage
     }));
-
-    setCommitState("DURING");
     
-    const response = fetch("/api/uploads/confirm", {
+    const response = await fetch("/api/uploads/confirm", {
       method: "POST",
       body: uploadRequestBody,
     });
+
+    if(response.ok) {
+      setCommitState("SUCCESS");
+    } else {
+      setCommitState("FAIL");
+    }
   }
 
   return (

--- a/app/components/post/elements/upload-confirm-button.tsx
+++ b/app/components/post/elements/upload-confirm-button.tsx
@@ -56,18 +56,25 @@ export function UploadConfirmButton({ uploadFiles, isButtonEnabled }: UploadConf
         アップロードを確定する
       </button>
       <Modal isOpen={isModalOpen} style={modalStyle} onRequestClose={modalClose}>
-        <UploadResultModalContent />
-        {/* <UploadDuringModalContent /> */}
-        {/* <UploadModalHeader modalClose={modalClose} />
-        <UploadModalContent uploadFiles={uploadFiles} />
-        <hr className="mt-2 h-2" />
-        <UploadModalCommitMessage setCommitMessage={setCommitMessage} />
-        <UploadModalFooterButton
-          modalClose={modalClose}
-          uploadFiles={uploadFiles}
-          commitMessage={commitMessage}
-          setCommitState={setCommitState}
-        /> */}
+        {commitState === "BEFORE" ? (
+          <>
+            <UploadModalContent uploadFiles={uploadFiles} />
+            <hr className="mt-2 h-2" />
+            <UploadModalCommitMessage setCommitMessage={setCommitMessage} />
+            <UploadModalFooterButton
+              modalClose={modalClose}
+              uploadFiles={uploadFiles}
+              commitMessage={commitMessage}
+              setCommitState={setCommitState}
+            />
+          </>
+        ) : commitState === "DURING" ? (
+          <UploadDuringModalContent />
+        ) : commitState === "SUCCESS" ? (
+          <UploadResultModalContent result={"SUCCESS"} />
+        ) : commitState === "FAIL" ? (
+          <UploadResultModalContent result={"FAIL"} />
+        ) : null}
       </Modal>
     </>
   );

--- a/app/components/post/elements/upload-confirm-button.tsx
+++ b/app/components/post/elements/upload-confirm-button.tsx
@@ -4,9 +4,15 @@ import { useModal } from "@/app/hooks/toppage/useModal";
 import Modal from "react-modal";
 import { UploadModalHeader } from "./inmodal/upload-modal-header";
 import { UploadModalContent } from "./inmodal/upload-modal-content";
-import { UploadModalFooter } from "./inmodal/upload-modal-footer-button";
+import { UploadModalFooterButton } from "./inmodal/upload-modal-footer-button";
 import { UploadModalCommitMessage } from "./inmodal/upload-modal-commit-message";
 import { useState } from "react";
+
+import { PulseLoader } from "react-spinners";
+import { BsCheck2Circle } from "react-icons/bs";
+import { FaArrowRight } from "react-icons/fa";
+import { UploadResultModalContent } from "./inmodal/result/upload-result-modal-content";
+import { UploadDuringModalContent } from "./inmodal/during/upload-during-modal-content";
 
 const modalStyle = {
   overlay: {
@@ -32,9 +38,12 @@ interface UploadConfirmButtonProps {
   isButtonEnabled: boolean;
 }
 
+export type CommitState = "BEFORE" | "DURING" | "SUCCESS" | "FAIL";
+
 export function UploadConfirmButton({ uploadFiles, isButtonEnabled }: UploadConfirmButtonProps) {
   const { isModalOpen, modalOpen, modalClose } = useModal();
   const [commitMessage, setCommitMessage] = useState<string>("");
+  const [commitState, setCommitState] = useState<CommitState>("BEFORE");
 
   return (
     <>
@@ -47,11 +56,18 @@ export function UploadConfirmButton({ uploadFiles, isButtonEnabled }: UploadConf
         アップロードを確定する
       </button>
       <Modal isOpen={isModalOpen} style={modalStyle} onRequestClose={modalClose}>
-        <UploadModalHeader modalClose={modalClose} />
+        <UploadResultModalContent />
+        {/* <UploadDuringModalContent /> */}
+        {/* <UploadModalHeader modalClose={modalClose} />
         <UploadModalContent uploadFiles={uploadFiles} />
         <hr className="mt-2 h-2" />
         <UploadModalCommitMessage setCommitMessage={setCommitMessage} />
-        <UploadModalFooter modalClose={modalClose} uploadFiles={uploadFiles} commitMessage={commitMessage} />
+        <UploadModalFooterButton
+          modalClose={modalClose}
+          uploadFiles={uploadFiles}
+          commitMessage={commitMessage}
+          setCommitState={setCommitState}
+        /> */}
       </Modal>
     </>
   );


### PR DESCRIPTION
# 概要
アップロード確定ボタン押下後にモーダルを遷移させる実装です。

# 関連 Issue

close https://github.com/warabimochi1126/EnvHub/issues/150